### PR TITLE
Support passing in a custom CA

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "chai":          "~1.0.3",
-    "mocha":         "~1.1.0",
+    "mocha":         "~2.2.5",
     "coffee-script": ">=1.6.3",
     "hubot-test-helper": "0.0.2"
   },

--- a/src/deployment.coffee
+++ b/src/deployment.coffee
@@ -8,7 +8,6 @@ ApiConfig = require(Path.join(__dirname, "api_config")).ApiConfig
 
 class Deployment
   @APPS_FILE = process.env['HUBOT_DEPLOY_APPS_JSON'] or "apps.json"
-  @CA_FILE = process.env['HUBOT_CA_FILE']
 
   constructor: (@name, @ref, @task, @env, @force, @hosts) ->
     @room             = 'unknown'
@@ -18,7 +17,7 @@ class Deployment
     @autoMerge        = true
     @environments     = [ "production" ]
     @requiredContexts = null
-    @caFile           = Fs.readFileSync(@constructor.CA_FILE) if @constructor.CA_FILE
+    @caFile           = Fs.readFileSync(process.env['HUBOT_CA_FILE']) if process.env['HUBOT_CA_FILE']
 
     try
       applications = JSON.parse(Fs.readFileSync(@constructor.APPS_FILE).toString())

--- a/src/deployment.coffee
+++ b/src/deployment.coffee
@@ -8,6 +8,7 @@ ApiConfig = require(Path.join(__dirname, "api_config")).ApiConfig
 
 class Deployment
   @APPS_FILE = process.env['HUBOT_DEPLOY_APPS_JSON'] or "apps.json"
+  @CA_FILE = process.env['HUBOT_CA_FILE']
 
   constructor: (@name, @ref, @task, @env, @force, @hosts) ->
     @room             = 'unknown'
@@ -17,6 +18,7 @@ class Deployment
     @autoMerge        = true
     @environments     = [ "production" ]
     @requiredContexts = null
+    @caFile           = Fs.readFileSync(@constructor.CA_FILE) if @constructor.CA_FILE
 
     try
       applications = JSON.parse(Fs.readFileSync(@constructor.APPS_FILE).toString())
@@ -78,6 +80,7 @@ class Deployment
   api: ->
     api = Octonode.client(@apiConfig().token, { hostname: @apiConfig().hostname })
     api.requestDefaults.headers['Accept'] = 'application/vnd.github.cannonball-preview+json'
+    api.requestDefaults.agentOptions = { ca: @caFile } if @caFile
     api
 
   latest: (cb) ->

--- a/test/deployment_test.coffee
+++ b/test/deployment_test.coffee
@@ -50,6 +50,20 @@ describe "Deployment fixtures", () ->
       deployment = new Deployment("restricted-app", "master", "deploy", "production", "", "")
       assert.equal(deployment.isAllowedRoom('watercooler'), false)
 
+  describe "#api", () ->
+    context "with no ca file", () ->
+      it "doesnt set agentOptions", () ->
+        deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
+        api = deployment.api()
+        assert.equal(api.requestDefaults.agentOptions, null)
+
+    context "with ca file", () ->
+      it "sets agentOptions.ca", () ->
+        process.env.HUBOT_CA_FILE = Path.join(__dirname, "fixtures", "cafile.txt")
+        deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
+        api = deployment.api()
+        assert(api.requestDefaults.agentOptions.ca)
+
   #describe "#latest()", () ->
   #  it "fetches the latest deployments", (done) ->
   #    deployment = new Deployment("hubot")

--- a/test/fixtures/cafile.txt
+++ b/test/fixtures/cafile.txt
@@ -1,0 +1,1 @@
+Sample CAFile


### PR DESCRIPTION
At my work, we use github enterprise with an SSL certificate signed by our own CA. The api requires SSL, therefore without this option any connection would fail with `unable to verify the first certificate`. We can make use of [agentOptions](https://github.com/request/request#using-optionsagentoptions) in the requests library to pass in our own CA and make the SSL connections succeed.