### PR TITLE
Auth user for getting deployment statuses

### DIFF
--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -46,6 +46,11 @@ module.exports = (robot) ->
 
     try
       deployment = new Deployment(name, null, null, environment)
+
+      user = robot.brain.userForId msg.envelope.user.id
+      if user? and user.githubDeployToken?
+        deployment.setUserToken(user.githubDeployToken)
+
       deployment.latest (deployments) ->
         formatter = new Formatters.LatestFormatter(deployment, deployments)
         msg.send formatter.message()


### PR DESCRIPTION
The command to list deploys wasn't working for us as the github auth token wasn't being set.

Apologies if I've overlooked something, otherwise hopefully this is a quick fix.