### PR TITLE
Fix Flowdock deployment replies sent by Heaven

### DIFF
--- a/src/deployment.coffee
+++ b/src/deployment.coffee
@@ -13,7 +13,8 @@ class Deployment
     @room             = 'unknown'
     @user             = 'unknown'
     @adapter          = 'unknown'
-    @message_thread   = 'unknown'
+    @thread_id        = 'unknown'
+    @message_id       = 'unknown'
     @autoMerge        = true
     @environments     = [ "production" ]
     @requiredContexts = null
@@ -67,7 +68,8 @@ class Deployment
         room: @room
         user: @user
         adapter: @adapter
-        message_thread: @message_thread
+        message_id: @message_id
+        thread_id: @thread_id
       config: @application
 
   setUserToken: (token) ->

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -92,7 +92,8 @@ module.exports = (robot) ->
     deployment.room = msg.message.user.room
 
     if robot.adapterName == 'flowdock'
-      deployment.message_thread = msg.message.user.message || msg.message.user.thread_id
+      deployment.thread_id = msg.message.metadata.thread_id
+      deployment.message_id = msg.message.id
 
     deployment.adapter = robot.adapterName
 


### PR DESCRIPTION
Set thread_id and message_id parameters as expected by Heaven Flowdock notified. This allows Heaven to reply to the same thread.