### PR TITLE
Lock Hubot at 2.13.2 to fix broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "dependencies": {
-    "hubot": ">=2.7.2",
+    "hubot": ">=2.7.2 <=2.13.2",
     "timeago": "0.1.0",
     "sprintf": "0.1.3",
     "octonode": "0.5.0",


### PR DESCRIPTION
The changes in Hubot 2.14.0 seem to have broken some of the tests here. I don't know whether it's the tests themselves or hubot-test-helper causing the tests, but for now we should lock Hubot at 2.13.2 to keep the tests green. 

Eventually, the tests and/or supporting libraries should be fixed to make the tests green again. I don't know whether you want to do that in this PR or break it out into a separate one, but I'm happy to help out.

Addresses #50