### PR TITLE
Embed the robot's name in the deployment payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/models/deployment.coffee
+++ b/src/models/deployment.coffee
@@ -13,6 +13,7 @@ class Deployment
     @room             = 'unknown'
     @user             = 'unknown'
     @adapter          = 'unknown'
+    @robotName        = 'hubot'
     @autoMerge        = true
     @environments     = [ "production" ]
     @requiredContexts = null
@@ -64,6 +65,7 @@ class Deployment
     description: "#{@task} on #{@env} from hubot-deploy-v#{Version}"
     payload:
       name: @name
+      robotName: @robotName
       hosts: @hosts
       yubikey: @yubikey
       notify:

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -102,8 +102,9 @@ module.exports = (robot) ->
       if msg.envelope.user.reply_to?
         deployment.room = msg.envelope.user.reply_to
 
-    deployment.adapter = robot.adapterName
-    deployment.yubikey = yubikey
+    deployment.yubikey   = yubikey
+    deployment.adapter   = robot.adapterName
+    deployment.robotName = robot.name
 
     if process.env.HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS
       robot.emit "github_deployment", msg, deployment


### PR DESCRIPTION
This allows for more than one robot and let's them figure out whether they were asked to deploy.