### PR TITLE
Start testing around deployment objects

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -5,6 +5,6 @@
 REPORTER = "min"
 
 task "test", "run tests", ->
-  exec "NODE_ENV=test ./node_modules/.bin/mocha test/**/*_test.coffee", (err, output) ->
+  exec "NODE_ENV=test ./node_modules/.bin/mocha test/**/*_test.coffee test/**/**/*_test.coffee", (err, output) ->
     console.log output
     throw err if err

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/models/deployment.coffee
+++ b/src/models/deployment.coffee
@@ -88,17 +88,13 @@ class Deployment
     api.requestDefaults.agentOptions = { ca: @caFile } if @caFile
     api
 
-  latest: (cb) ->
+  latest: (callback) ->
     path       = @apiConfig().path("repos/#{@repository}/deployments")
     params     =
       environment: @env
 
     @api().get path, params, (err, status, body, headers) ->
-      if err
-        body = err
-        console.log err['message'] unless process.env.NODE_ENV == 'test'
-
-      cb(body)
+      callback(err, body)
 
   post: (cb) ->
     path       = @apiConfig().path("repos/#{@repository}/deployments")

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -52,7 +52,7 @@ module.exports = (robot) ->
       if user? and user.githubDeployToken?
         deployment.setUserToken(user.githubDeployToken)
 
-      deployment.latest (deployments) ->
+      deployment.latest (err, deployments) ->
         formatter = new Formatters.LatestFormatter(deployment, deployments)
         robot.emit "hubot_deploy_recent_deployments", msg, deployment, deployments, formatter
 

--- a/test/models/deployment_test.coffee
+++ b/test/models/deployment_test.coffee
@@ -4,56 +4,12 @@ Version    = require(Path.join(__dirname, "..", "..", "src", "version")).Version
 Deployment = require(Path.join(__dirname, "..", "..", "src", "models", "deployment")).Deployment
 
 describe "Deployment fixtures", () ->
-  describe "#isValidApp()", () ->
-    it "is invalid if the app can't be found", () ->
-      deployment = new Deployment("hubot-reloaded", "master", "deploy", "production", "", "")
-      assert.equal(deployment.isValidApp(), false)
 
-    it "is valid if the app can be found", () ->
-      deployment = new Deployment("hubot-deploy", "master", "deploy", "production", "", "")
-      assert.equal(deployment.isValidApp(), true)
-
-  describe "#isValidEnv()", () ->
-    it "is invalid if the env can't be found", () ->
-      deployment = new Deployment("hubot", "master", "deploy", "garage", "", "")
-      assert.equal(deployment.isValidEnv(), false)
-
-    it "is valid if the env can be found", () ->
-      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
-      assert.equal(deployment.isValidEnv(), true)
 
   describe "#autoMerge", () ->
     it "works with auto-merging", () ->
       deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
       assert.equal(false, deployment.autoMerge)
-
-  describe "#requiredContexts", () ->
-    it "works with required contexts", () ->
-      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
-      expectedContexts = ["ci/janky", "ci/travis-ci"]
-
-      assert.deepEqual(expectedContexts, deployment.requiredContexts)
-
-  describe "#requestBody()", () ->
-    it "shouldn't blow up", () ->
-      deployment = new Deployment("hubot", "master", "deploy", "garage", "", "")
-      deployment.requestBody()
-      assert.equal(true, true)
-    it "should have the right description", () ->
-      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
-      body = deployment.requestBody()
-      assert.equal(body.description, "deploy on production from hubot-deploy-v#{Version}")
-
-  describe "#isAllowedRoom()", () ->
-    it "allows everything when there is no configuration", ->
-      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
-      assert.equal(deployment.isAllowedRoom('anything'), true)
-    it "is allowed with room that is in configuration", ->
-      deployment = new Deployment("restricted-app", "master", "deploy", "production", "", "")
-      assert.equal(deployment.isAllowedRoom('ops'), true)
-    it "is not allowed with room that is not in configuration", ->
-      deployment = new Deployment("restricted-app", "master", "deploy", "production", "", "")
-      assert.equal(deployment.isAllowedRoom('watercooler'), false)
 
   describe "#api", () ->
     context "with no ca file", () ->

--- a/test/models/deployments/instance_methods_test.coffee
+++ b/test/models/deployments/instance_methods_test.coffee
@@ -1,0 +1,55 @@
+Path = require "path"
+
+srcDir = Path.join(__dirname, "..", "..", "..", "src")
+
+Version    = require(Path.join(srcDir, "version")).Version
+Deployment = require(Path.join(srcDir, "models", "deployment")).Deployment
+
+describe "Deployment fixtures", () ->
+  describe "#isValidApp()", () ->
+    it "is invalid if the app can't be found", () ->
+      deployment = new Deployment("hubot-reloaded", "master", "deploy", "production", "", "")
+      assert.equal(deployment.isValidApp(), false)
+
+    it "is valid if the app can be found", () ->
+      deployment = new Deployment("hubot-deploy", "master", "deploy", "production", "", "")
+      assert.equal(deployment.isValidApp(), true)
+
+  describe "#isValidEnv()", () ->
+    it "is invalid if the env can't be found", () ->
+      deployment = new Deployment("hubot", "master", "deploy", "garage", "", "")
+      assert.equal(deployment.isValidEnv(), false)
+
+    it "is valid if the env can be found", () ->
+      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
+      assert.equal(deployment.isValidEnv(), true)
+
+  describe "#requiredContexts", () ->
+    it "works with required contexts", () ->
+      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
+      expectedContexts = ["ci/janky", "ci/travis-ci"]
+
+      assert.deepEqual(expectedContexts, deployment.requiredContexts)
+
+  describe "#isAllowedRoom()", () ->
+    it "allows everything when there is no configuration", ->
+      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
+      assert.equal(deployment.isAllowedRoom('anything'), true)
+    it "is allowed with room that is in configuration", ->
+      deployment = new Deployment("restricted-app", "master", "deploy", "production", "", "")
+      assert.equal(deployment.isAllowedRoom('ops'), true)
+    it "is not allowed with room that is not in configuration", ->
+      deployment = new Deployment("restricted-app", "master", "deploy", "production", "", "")
+      assert.equal(deployment.isAllowedRoom('watercooler'), false)
+
+  describe "#requestBody()", () ->
+    it "shouldn't blow up", () ->
+      deployment = new Deployment("hubot", "master", "deploy", "garage", "", "")
+      deployment.requestBody()
+      assert.equal(true, true)
+    it "should have the right description", () ->
+      deployment = new Deployment("hubot", "master", "deploy", "production", "", "")
+      body = deployment.requestBody()
+      assert.equal(body.description, "deploy on production from hubot-deploy-v#{Version}")
+
+

--- a/test/models/deployments/latest_test.coffee
+++ b/test/models/deployments/latest_test.coffee
@@ -17,7 +17,9 @@ describe "Deployment#latest", () ->
     deployment = new Deployment("hubot-deploy", "master", "deploy", "production", "", "")
     deployment.latest (err, deployments) ->
       throw err if err
-      assert.deepEqual [ ], deployments
+      assert.equal "hubot-deploy", deployment.name
+      assert.equal "production", deployment.env
+      assert.equal 2, deployments.length
       done()
 
   it "gets the latest deployments from the api", (done) ->
@@ -25,6 +27,8 @@ describe "Deployment#latest", () ->
     deployment = new Deployment("hubot-deploy", "master", "deploy", "staging", "", "")
     deployment.latest (err, deployments) ->
       throw err if err
-      assert.deepEqual [ ], deployments
+      assert.equal "hubot-deploy", deployment.name
+      assert.equal "staging", deployment.env
+      assert.equal 2, deployments.length
       done()
 

--- a/test/models/deployments/latest_test.coffee
+++ b/test/models/deployments/latest_test.coffee
@@ -1,0 +1,30 @@
+VCR  = require "ys-vcr"
+Path = require "path"
+
+srcDir = Path.join(__dirname, "..", "..", "..", "src")
+
+Version    = require(Path.join(srcDir, "version")).Version
+Deployment = require(Path.join(srcDir, "models", "deployment")).Deployment
+
+describe "Deployment#latest", () ->
+  beforeEach () ->
+    VCR.playback()
+  afterEach () ->
+    VCR.stop()
+
+  it "gets the latest deployments from the api", (done) ->
+    VCR.play '/github-deployments-latest-production-success'
+    deployment = new Deployment("hubot-deploy", "master", "deploy", "production", "", "")
+    deployment.latest (err, deployments) ->
+      throw err if err
+      assert.deepEqual [ ], deployments
+      done()
+
+  it "gets the latest deployments from the api", (done) ->
+    VCR.play '/github-deployments-latest-staging-success'
+    deployment = new Deployment("hubot-deploy", "master", "deploy", "staging", "", "")
+    deployment.latest (err, deployments) ->
+      throw err if err
+      assert.deepEqual [ ], deployments
+      done()
+

--- a/test/scripts/latest_deploys_test.coffee
+++ b/test/scripts/latest_deploys_test.coffee
@@ -1,0 +1,55 @@
+VCR           = require "ys-vcr"
+Path          = require "path"
+Robot         = require "hubot/src/robot"
+TextMessage   = require("hubot/src/message").TextMessage
+Verifiers     = require(Path.join(__dirname, "..", "..", "src", "models", "verifiers"))
+
+describe "Latest deployments", () ->
+  user  = null
+  robot = null
+  adapter = null
+
+  beforeEach (done) ->
+    VCR.playback()
+    process.env.HUBOT_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
+    robot = new Robot(null, "mock-adapter", true, "Hubot")
+
+    robot.adapter.on "connected", () ->
+      require("hubot-vault")(robot)
+      require("../../index")(robot)
+
+      userInfo =
+        name: "atmos",
+        room: "#my-room"
+
+      user    = robot.brain.userForId "1", userInfo
+      adapter = robot.adapter
+
+      done()
+
+    robot.run()
+
+  afterEach () ->
+    VCR.stop()
+    robot.server.close()
+    robot.shutdown()
+
+  it "tells you the latest production deploys", (done) ->
+    VCR.play '/github-deployments-latest-production-success'
+    robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
+      assert.equal "hubot-deploy", deployment.name
+      assert.equal "production", deployment.env
+      assert.deepEqual [ ], deployments
+      done()
+
+    adapter.receive(new TextMessage(user, "Hubot deploys hubot-deploy in production"))
+
+  it "tells you the latest staging deploys", (done) ->
+    VCR.play '/github-deployments-latest-staging-success'
+    robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
+      assert.equal "hubot-deploy", deployment.name
+      assert.equal "staging", deployment.env
+      assert.deepEqual [ ], deployments
+      done()
+
+    adapter.receive(new TextMessage(user, "Hubot deploys hubot-deploy in staging"))

--- a/test/scripts/latest_deploys_test.coffee
+++ b/test/scripts/latest_deploys_test.coffee
@@ -39,7 +39,7 @@ describe "Latest deployments", () ->
     robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
       assert.equal "hubot-deploy", deployment.name
       assert.equal "production", deployment.env
-      assert.deepEqual [ ], deployments
+      assert.deepEqual 2, deployments.length
       done()
 
     adapter.receive(new TextMessage(user, "Hubot deploys hubot-deploy in production"))
@@ -49,7 +49,7 @@ describe "Latest deployments", () ->
     robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
       assert.equal "hubot-deploy", deployment.name
       assert.equal "staging", deployment.env
-      assert.deepEqual [ ], deployments
+      assert.deepEqual 2, deployments.length
       done()
 
     adapter.receive(new TextMessage(user, "Hubot deploys hubot-deploy in staging"))

--- a/test/scripts/latest_deploys_test.coffee
+++ b/test/scripts/latest_deploys_test.coffee
@@ -39,7 +39,7 @@ describe "Latest deployments", () ->
     robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
       assert.equal "hubot-deploy", deployment.name
       assert.equal "production", deployment.env
-      assert.deepEqual 2, deployments.length
+      assert.equal 2, deployments.length
       done()
 
     adapter.receive(new TextMessage(user, "Hubot deploys hubot-deploy in production"))
@@ -49,7 +49,7 @@ describe "Latest deployments", () ->
     robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
       assert.equal "hubot-deploy", deployment.name
       assert.equal "staging", deployment.env
-      assert.deepEqual 2, deployments.length
+      assert.equal 2, deployments.length
       done()
 
     adapter.receive(new TextMessage(user, "Hubot deploys hubot-deploy in staging"))

--- a/test/scripts/tokens_test.coffee
+++ b/test/scripts/tokens_test.coffee
@@ -2,7 +2,7 @@ VCR           = require "ys-vcr"
 Path          = require "path"
 Robot         = require "hubot/src/robot"
 TextMessage   = require("hubot/src/message").TextMessage
-Verifiers     = require("./../../src/models/verifiers")
+Verifiers     = require(Path.join(__dirname, "..", "..", "src", "models", "verifiers"))
 
 describe "Setting tokens and such", () ->
   user  = null

--- a/test/support/cassettes/github_latest_deployments.coffee
+++ b/test/support/cassettes/github_latest_deployments.coffee
@@ -1,0 +1,19 @@
+module.exports.cassettes =
+  '/github-deployments-latest-production-success':
+    host: 'https://api.github.com:443'
+    path: '/repos/atmos/hubot-deploy/deployments'
+    code: 200
+    params:
+      environment: 'production'
+    path: '/repos/atmos/hubot-deploy/deployments'
+    body: [
+    ]
+  '/github-deployments-latest-staging-success':
+    host: 'https://api.github.com:443'
+    path: '/repos/atmos/hubot-deploy/deployments'
+    params:
+      environment: 'southside'
+    code: 200
+    path: '/repos/atmos/hubot-deploy/deployments'
+    body: [
+    ]

--- a/test/support/cassettes/github_latest_deployments.coffee
+++ b/test/support/cassettes/github_latest_deployments.coffee
@@ -7,13 +7,149 @@ module.exports.cassettes =
       environment: 'production'
     path: '/repos/atmos/hubot-deploy/deployments'
     body: [
+      {
+        id: 2332339,
+        url: "https://api.github.com/repos/atmos/hubot-deploy/deployments/2332339"
+        sha: "afa77dd02e61d86e73795796207e128206d670e2"
+        ref: "master"
+        task: "deploy"
+        environment: "production",
+        description: "deploy on production from hubot-deploy-v0.10.1",
+        payload:
+          name: "hubot"
+          robotName: "hubot"
+          notify:
+            adapter: "slack"
+            room: "#general"
+            user: "341"
+          config:
+            provider: "heroku",
+            repository: "atmos/hubot-deploy",
+            environments: [
+              "production"
+              "staging"
+            ]
+            required_contexts: [
+              "continuous-integration/travis-ci/push"
+            ]
+            heroku_production_name: "hubot-deploy-production"
+            heroku_staging_name: "hubot-deploy-staging"
+        creator:
+          id: 38,
+          login: "atmos",
+          avatar_url: "https://avatars.githubusercontent.com/u/38?v=3"
+      }
+      {
+        id: 2332369,
+        url: "https://api.github.com/repos/atmos/hubot-deploy/deployments/2332369"
+        sha: "afa77dd02e61d86e73795796207e128206d670e2"
+        ref: "master"
+        task: "deploy"
+        environment: "production",
+        description: "deploy on production from hubot-deploy-v0.10.1",
+        payload:
+          name: "hubot"
+          robotName: "hubot"
+          notify:
+            adapter: "slack"
+            room: "#general"
+            user: "341"
+          config:
+            provider: "heroku",
+            repository: "atmos/hubot-deploy",
+            environments: [
+              "production"
+              "staging"
+            ]
+            required_contexts: [
+              "continuous-integration/travis-ci/push"
+            ]
+            heroku_production_name: "hubot-deploy-production"
+            heroku_staging_name: "hubot-deploy-staging"
+        creator:
+          id: 38,
+          login: "atmos",
+          avatar_url: "https://avatars.githubusercontent.com/u/38?v=3"
+      }
     ]
   '/github-deployments-latest-staging-success':
     host: 'https://api.github.com:443'
     path: '/repos/atmos/hubot-deploy/deployments'
     params:
-      environment: 'southside'
+      environment: 'staging'
     code: 200
     path: '/repos/atmos/hubot-deploy/deployments'
     body: [
+      {
+        id: 2332339,
+        url: "https://api.github.com/repos/atmos/hubot-deploy/deployments/2332339"
+        sha: "afa77dd02e61d86e73795796207e128206d670e2"
+        ref: "master"
+        task: "deploy"
+        environment: "staging",
+        description: "deploy on staging from hubot-deploy-v0.10.1",
+        payload:
+          name: "hubot"
+          robotName: "hubot"
+          notify:
+            adapter: "slack"
+            room: "#general"
+            user: "341"
+          config:
+            provider: "heroku",
+            repository: "atmos/hubot-deploy",
+            environments: [
+              "production"
+              "staging"
+            ]
+            required_contexts: [
+              "continuous-integration/travis-ci/push"
+            ]
+            heroku_production_name: "hubot-deploy-production"
+            heroku_staging_name: "hubot-deploy-staging"
+        creator:
+          id: 38,
+          login: "atmos",
+          avatar_url: "https://avatars.githubusercontent.com/u/38?v=3"
+      }
+      {
+        id: 2332369,
+        url: "https://api.github.com/repos/atmos/hubot-deploy/deployments/2332369"
+        sha: "afa77dd02e61d86e73795796207e128206d670e2"
+        ref: "master"
+        task: "deploy"
+        environment: "staging",
+        description: "deploy on staging from hubot-deploy-v0.10.1",
+        payload:
+          name: "hubot"
+          robotName: "hubot"
+          notify:
+            adapter: "slack"
+            room: "#general"
+            user: "341"
+          config:
+            provider: "heroku",
+            repository: "atmos/hubot-deploy",
+            environments: [
+              "production"
+              "staging"
+            ]
+            required_contexts: [
+              "continuous-integration/travis-ci/push"
+            ]
+            heroku_production_name: "hubot-deploy-production"
+            heroku_staging_name: "hubot-deploy-staging"
+        creator:
+          id: 38,
+          login: "atmos",
+          avatar_url: "https://avatars.githubusercontent.com/u/38?v=3"
+      }
     ]
+  '/github-deployments-latest-production-bad-auth':
+    host: 'https://api.github.com:443'
+    path: '/repos/atmos/hubot-deploy/deployments'
+    code: 401
+    path: '/repos/atmos/hubot-deploy/deployments'
+    body:
+      message: "Bad credentials"
+      documentation_url: "https://developer.github.com/v3"


### PR DESCRIPTION
This gets more tests in place and starts breaking down the massive Deployment object.

The only notable change is the `latest` method on deployment had a small signature change.