### PR TITLE
Shift away from suggesting heaven

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -39,9 +39,16 @@ Any extra parameters will be passed along to GitHub in the `payload` field. This
 }
 ```
 
-## Supported GitHub Services
+## Providers
 
-GitHub has really simple integrations for Heroku and OpsWorks. The cool thing about these is that you can get deployment support without having to setup and services of your own.
+### Heroku
+
+There's another plugin for hubot called [hubot-deploy-heroku](https://github.com/atmos/hubot-deploy-heroku).
+
+
+## Deprecated GitHub Services
+
+GitHub has service integrations for Heroku and OpsWorks. This allows you to get deployment support without having to setup an service of your own.
 
 ### Heroku
 
@@ -57,5 +64,4 @@ There's also a repo integration for deploying to [Aws OpsWorks](http://aws.amazo
 
 ## Supported Heaven Services
 
-The [heaven](https://github.com/atmos/heaven) exists if you need to write your own custom stuff or don't want to share your keys with GitHub. This requires you to stand up your own service, but deploys to heroku relatively easily. The best docs are probably the readme.
-
+There is also [heaven](https://github.com/atmos/heaven) which exists if you need to write your own custom stuff or don't want to share your keys with GitHub. This requires you to stand up your own service, but deploys to heroku relatively easily.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,30 +5,34 @@ In order to create deployments on GitHub you need to configure a few things. Fal
 | Common Attributes       |                                                 |
 |-------------------------|-------------------------------------------------|
 | HUBOT_GITHUB_API        | A String of the full URL to the GitHub API. Default: "https://api.github.com" |
-| HUBOT_GITHUB_TOKEN      | A [personal oauth token][1] with repo_deployment scope. |
-| HUBOT_FERNET_SECRETS    | The key used for encrypting your tokens in the hubot's brain.|
-| HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS | If set to true a `github_deployment` event emit emitted instead of posting to the GitHub API. This allows you to do customization of your deployment. |
+| HUBOT_GITHUB_TOKEN      | A [personal oauth token][1] with repo_deployment scope. This is normally a bot account. |
+| HUBOT_FERNET_SECRETS    | The key used for encrypting your tokens in the hubot's brain. |
+| HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS | If set to true a `github_deployment` event emit emitted instead of posting directly to the GitHub API. This allows for customization, check out the examples. |
 
-### The Highlander Token
+### Robot Users
 
-If you're only going to use the `HUBOT_GITHUB_TOKEN` then all deployments will be created by a single user. Since you're deploying from chat, it's nice to know who requested the actual deployment.
+If you already have a user on GitHub that is essentially a bot account you can create a [personal OAuth token][1] for that user with the `user` and `repo` scopes. Unfortunately GitHub won't be able to differentiate between different users deploying, they'll all be created in the API as the bot user.
 
 ### User Tokens
 
-The hubot-deploy script provides a way to have user specific tokens for interacting with the API.
+The hubot-deploy script provides a way to have user specific tokens for interacting with the API. You need to be using a chat service that supports private messages like [SlackHQ][2] or [Hipchat][3].
 
-**To prevent chat networks from logging your password it's good practice to lock the room or use private messages if available.**
+To configure your own token, make a [personal OAuth token][1] with both `user`, `repo` scopes. Then provide it to hubot via private message.
 
-To configure your own token, make a [personal OAuth token][1] with both `user`, `repo` scopes. Then provide it to hubot.
+    deploy-token:set:github <mytoken>
 
-    $ hubot deploy-token:set:github <mytoken>
+Hubot will respond and tell you whether the token is sufficient or not. If your token is good future deployments will be properly attributed to your user in the API.
 
-Hubot will respond and tell you whether the token is sufficient or not. Subsequent deployments will be properly attributed to your user in the API.
+If things are being weird you can verify your token.
+
+    deploy-token:verify:github
 
 If you want to go back having the highlander token create your deployments you can reset things like.
 
-    $ hubot deploy-token:reset:github
+    deploy-token:reset:github
 
 Hubot will respond and tell you that your token has been forgotten and removed from the robot's brain.
 
 [1]: https://github.com/settings/tokens
+[2]: https://slack.com/is
+[3]: https://www.hipchat.com

--- a/docs/examples/hipchat.coffee
+++ b/docs/examples/hipchat.coffee
@@ -1,0 +1,65 @@
+# Description
+#  Custom hubot-deploy scripts for hipchat
+#
+process.env.HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS = "true"
+
+###########################################################################
+module.exports = (robot) ->
+  #########################################################################
+  # This is what happens with a '/deploy' request is accepted.
+  #
+  # msg - The hubot message that triggered the deployment. msg.reply and msg.send post back immediately
+  # deployment - The deployment captured from a chat interaction. You can modify it before it's passed on to the GitHub API.
+  robot.on "github_deployment", (msg, deployment) ->
+    # Handle the difference between userIds and roomIds in hipchat
+    user = robot.brain.userForId deployment.user
+    unless user.id?.match(/\d+/)
+      user = robot.brain.userByNameOrMention(user.id)
+      deployment.user = user.id if user.id?
+
+    vault = robot.vault.forUser(user)
+    githubDeployToken = vault.get "hubot-deploy-github-secret"
+    if githubDeployToken?
+      deployment.setUserToken(githubDeployToken)
+
+    if deployment.application.provider in [ "heroku", "capistrano" ]
+      deployment.post (err, status, body, headers, responseMessage) ->
+        msg.send responseMessage if responseMessage?
+    else
+      msg.send "Sorry, I can't deploy #{deployment.name}, the provider is unsupported"
+
+  #########################################################################
+  # Reply with the most recent deployments that the api is aware of
+  #
+  # msg - The hubot message that triggered the deployment. msg.reply and msg.send post back immediately
+  # deployment - The deployed app that matched up with the request.
+  # deployments - The list of the most recent deployments from the GitHub API.
+  # formatter - A basic formatter for the deployments that should work everywhere even though it looks gross.
+  robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
+    msg.send formatter.message()
+
+  #########################################################################
+  # Reply with the environments that hubot-deploy knows about for a specific application.
+  #
+  # msg - The hubot message that triggered the deployment. msg.reply and msg.send post back immediately
+  # deployment - The deployed app that matched up with the request.
+  # formatter - A basic formatter for the deployments that should work everywhere even though it looks gross.
+  robot.on "hubot_deploy_available_environments", (msg, deployment) ->
+    msg.send "#{deployment.name} can be deployed to #{deployment.environments.join(', ')}."
+
+  #########################################################################
+  # deployment - The deployment event webhook from the GitHub API.
+  robot.on "github_deployment_event", (deployment) ->
+    robot.logger.info JSON.stringify(deployment)
+
+  #########################################################################
+  # status - The deployment status event webhook from the GitHub API.
+  robot.on "github_deployment_status_event", (status) ->
+    if status.notify
+      user  = robot.brain.userForId status.notify.user
+      status.actorName = user.name
+
+    messageBody = status.toSimpleString().replace(/^hubot-deploy: /i, '')
+    robot.logger.info messageBody
+    if status?.notify?.room? and status.notify.room isnt spamChannel
+      robot.messageRoom status.notify.room, messageBody

--- a/docs/examples/hipchat.coffee
+++ b/docs/examples/hipchat.coffee
@@ -48,12 +48,16 @@ module.exports = (robot) ->
     msg.send "#{deployment.name} can be deployed to #{deployment.environments.join(', ')}."
 
   #########################################################################
+  # An incoming webhook from GitHub for a deployment. This is where you dispatch to app specific providers.
+  #
   # deployment - The deployment event webhook from the GitHub API.
   robot.on "github_deployment_event", (deployment) ->
     robot.logger.info JSON.stringify(deployment)
 
   #########################################################################
-  # status - The deployment status event webhook from the GitHub API.
+  # An incoming webhook from GitHub for a deployment status. This is chat feedback.
+  #
+  # status - The deployment status
   robot.on "github_deployment_status_event", (status) ->
     if status.notify
       user  = robot.brain.userForId status.notify.user

--- a/docs/examples/hipchat.coffee
+++ b/docs/examples/hipchat.coffee
@@ -65,5 +65,5 @@ module.exports = (robot) ->
 
     messageBody = status.toSimpleString().replace(/^hubot-deploy: /i, '')
     robot.logger.info messageBody
-    if status?.notify?.room? and status.notify.room isnt spamChannel
+    if status?.notify?.room?
       robot.messageRoom status.notify.room, messageBody

--- a/docs/examples/hipchat.coffee
+++ b/docs/examples/hipchat.coffee
@@ -48,16 +48,16 @@ module.exports = (robot) ->
     msg.send "#{deployment.name} can be deployed to #{deployment.environments.join(', ')}."
 
   #########################################################################
-  # An incoming webhook from GitHub for a deployment. This is where you dispatch to app specific providers.
+  # An incoming webhook from GitHub for a deployment.
   #
-  # deployment - The deployment event webhook from the GitHub API.
+  # deployment - A Deployment from github_events.coffee
   robot.on "github_deployment_event", (deployment) ->
     robot.logger.info JSON.stringify(deployment)
 
   #########################################################################
-  # An incoming webhook from GitHub for a deployment status. This is chat feedback.
+  # An incoming webhook from GitHub for a deployment status.
   #
-  # status - The deployment status
+  # status - A DeploymentStatus from github_events.coffee
   robot.on "github_deployment_status_event", (status) ->
     if status.notify
       user  = robot.brain.userForId status.notify.user

--- a/docs/examples/hipchat.coffee
+++ b/docs/examples/hipchat.coffee
@@ -3,9 +3,7 @@
 #
 process.env.HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS = "true"
 
-###########################################################################
 module.exports = (robot) ->
-  #########################################################################
   # This is what happens with a '/deploy' request is accepted.
   #
   # msg - The hubot message that triggered the deployment. msg.reply and msg.send post back immediately
@@ -28,7 +26,6 @@ module.exports = (robot) ->
     else
       msg.send "Sorry, I can't deploy #{deployment.name}, the provider is unsupported"
 
-  #########################################################################
   # Reply with the most recent deployments that the api is aware of
   #
   # msg - The hubot message that triggered the deployment. msg.reply and msg.send post back immediately
@@ -38,7 +35,6 @@ module.exports = (robot) ->
   robot.on "hubot_deploy_recent_deployments", (msg, deployment, deployments, formatter) ->
     msg.send formatter.message()
 
-  #########################################################################
   # Reply with the environments that hubot-deploy knows about for a specific application.
   #
   # msg - The hubot message that triggered the deployment. msg.reply and msg.send post back immediately
@@ -47,14 +43,12 @@ module.exports = (robot) ->
   robot.on "hubot_deploy_available_environments", (msg, deployment) ->
     msg.send "#{deployment.name} can be deployed to #{deployment.environments.join(', ')}."
 
-  #########################################################################
   # An incoming webhook from GitHub for a deployment.
   #
   # deployment - A Deployment from github_events.coffee
   robot.on "github_deployment_event", (deployment) ->
     robot.logger.info JSON.stringify(deployment)
 
-  #########################################################################
   # An incoming webhook from GitHub for a deployment status.
   #
   # status - A DeploymentStatus from github_events.coffee


### PR DESCRIPTION
A bunch of the development over the last few months has been around handling organization hooks, two factor auth, and custom(private) provider support. So there's a bunch of cool stuff you can do now that previous required heaven. This should document and give examples for some advanced usage. 