### PR TITLE
Allow for overriding default chat deployment environments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ In order to create deployments on GitHub you need to configure a few things. Fal
 | HUBOT_GITHUB_TOKEN      | A [personal oauth token][1] with repo_deployment scope. This is normally a bot account. |
 | HUBOT_FERNET_SECRETS    | The key used for encrypting your tokens in the hubot's brain. |
 | HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS | If set to true a `github_deployment` event emit emitted instead of posting directly to the GitHub API. This allows for customization, check out the examples. |
+| HUBOT_DEPLOY_DEFAULT_ENVIRONMENT | Allow for specifying which environment should be the default when it is omitted from the deployment request in chat. |
 
 ### Robot Users
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -19,6 +19,9 @@ DeployPrefix   = Patterns.DeployPrefix
 DeployPattern  = Patterns.DeployPattern
 DeploysPattern = Patterns.DeploysPattern
 
+defaultDeploymentEnvironment = () ->
+  process.env.HUBOT_DEPLOY_DEFAULT_ENVIRONMENT || 'production'
+
 ###########################################################################
 module.exports = (robot) ->
   ###########################################################################
@@ -43,7 +46,7 @@ module.exports = (robot) ->
   # Displays the available environments for an application
   robot.respond DeploysPattern, (msg) ->
     name        = msg.match[2]
-    environment = msg.match[4] || 'production'
+    environment = msg.match[4] || defaultDeploymentEnvironment()
 
     try
       deployment = new Deployment(name, null, null, environment)
@@ -68,7 +71,7 @@ module.exports = (robot) ->
     force = msg.match[2] == '!'
     name  = msg.match[3]
     ref   = (msg.match[4]||'master')
-    env   = (msg.match[5]||'production')
+    env   = (msg.match[5]||defaultDeploymentEnvironment())
     hosts = (msg.match[6]||'')
     yubikey = msg.match[7]
 

--- a/test/support/cassettes/github_deployment_create.coffee
+++ b/test/support/cassettes/github_deployment_create.coffee
@@ -94,7 +94,7 @@ module.exports.cassettes =
             provider: "heroku",
             auto_merge: true,
             repository: "atmos/hubot-deploy",
-            environments: [ "production" ]
+            environments: [ "production", "staging" ]
             allowed_rooms: []
             heroku_name: "zero-fucks-hubot"
         creator:
@@ -115,3 +115,49 @@ module.exports.cassettes =
         login: "atmos"
         avatar_url: "https://avatars.githubusercontent.com/u/6626297?v=3"
 
+  '/repos-atmos-hubot-deploy-deployment-staging-create-success':
+    host: 'https://api.github.com:443'
+    path: '/repos/atmos/hubot-deploy/deployments'
+    method: 'post'
+    code: 201
+    path: '/repos/atmos/hubot-deploy/deployments'
+    body:
+      deployment:
+        url: "https://api.github.com/repos/atmos/hubot-deploy/deployments/1875476"
+        id: 1875476
+        sha: "3c9f42c76ce057eaabc3762e3ec46dd830976963"
+        ref: "heroku"
+        task: "deploy"
+        environment: "staging"
+        description: "Deploying from hubot-deploy-v0.6.53"
+        payload:
+          name: "hubot-deploy"
+          hosts: ""
+          notify:
+            room: "ops",
+            user: "atmos",
+            adapter: "slack",
+          config:
+            provider: "heroku",
+            auto_merge: true,
+            repository: "atmos/hubot-deploy",
+            environments: [ "production", "staging" ]
+            allowed_rooms: []
+            heroku_name: "zero-fucks-hubot"
+        creator:
+          id: 6626297,
+          login: "atmos",
+          avatar_url: "https://avatars.githubusercontent.com/u/6626297?v=3"
+      repository:
+        id: 42524818
+        name: "hubot-deploy"
+        private: true
+        full_name: "atmos/hubot-deploy"
+        owner:
+          login: "atmos",
+          type: "User",
+          site_admin: false
+      sender:
+        id: 6626297
+        login: "atmos"
+        avatar_url: "https://avatars.githubusercontent.com/u/6626297?v=3"

--- a/test/test_apps.json
+++ b/test/test_apps.json
@@ -11,7 +11,7 @@
 
   "hubot-deploy": {
     "repository": "atmos/hubot-deploy",
-    "environments": ["production"],
+    "environments": ["production", "staging"],
 
     "provider": "npm"
   },


### PR DESCRIPTION
The default behavior of hubot-deploy has always been to just ship production. That's kinda scary for people since they could unintentionally deploy to production if they forget to add the environment to the request string. You can now override the default value of "production" to any other named environment via the `HUBOT_DEPLOY_DEFAULT_ENVIRONMENT` environmental variable. It will still default to production though.