### PR TITLE
Allow for Google Authenticator / Authy formatted tokens too

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/models/patterns.coffee
+++ b/src/models/patterns.coffee
@@ -13,7 +13,7 @@ DEPLOY_SYNTAX = ///
   (?:\s+(?:to|in|on)\s+                 # http://i.imgur.com/3KqMoRi.gif
   #{validSlug}                          # Environment to release to
   (?:\/([^\s]+))?)?\s*                  # Host filter to try
-  (?:([cbdefghijklnrtuv]{32,64})?\s*)?$ # Optional Yubikey
+  (?:([cbdefghijklnrtuv]{32,64}|\d{6})?\s*)?$ # Optional Yubikey
 ///i
 
 

--- a/test/models/pattern_test.coffee
+++ b/test/models/pattern_test.coffee
@@ -79,6 +79,15 @@ describe "Patterns", () ->
       assert.equal "fe",           matches[6], "incorrect host name"
       assert.equal "ccccccdlnncbtuevhdbctrccukdciveuclhbkvehbeve", matches[7], "incorrect yubikey pattern"
 
+    it "handles branch deploys with slashes and environments with hosts plus 2fa keys", () ->
+      matches = "deploy hubot/atmos/branch to production/fe 123456".match(DeployPattern)
+      assert.equal "deploy",       matches[1], "incorrect task"
+      assert.equal "hubot",        matches[3], "incorrect app name"
+      assert.equal "atmos/branch", matches[4], "incorrect branch name"
+      assert.equal "production",   matches[5], "incorrect environment name"
+      assert.equal "fe",           matches[6], "incorrect host name"
+      assert.equal "123456",       matches[7], "incorrect authenticator token"
+
     it "doesn't match on malformed yubikeys", () ->
       matches = "deploy hubot/atmos/branch to production/fe burgers".match(DeployPattern)
       assert.equal null, matches


### PR DESCRIPTION
Lots of APIs allow authenticator style keys and yubikeys, this allows for both.