### PR TITLE
Bring in the parts of hubot-vault that I need

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 * Add hubot-deploy to your `package.json` file.
 * Add hubot-deploy to your `external-scripts.json` file.
-* [Configure](https://github.com/atmos/hubot-deploy/blob/master/docs/configuration.md) your runtime environment to interaction with the GitHub API.
+* [Configure](https://github.com/atmos/hubot-deploy/blob/master/docs/configuration.md) your runtime environment to interact with the GitHub API.
 * Understand how [apps.json](https://github.com/atmos/hubot-deploy/blob/master/docs/config-file.md) works.
 * Learn about [ChatOps](https://github.com/atmos/hubot-deploy/blob/master/docs/chatops.md) deploys.
 

--- a/index.coffee
+++ b/index.coffee
@@ -1,6 +1,11 @@
-Path = require 'path'
+Path  = require 'path'
+Vault = require('./src/hubot/vault.coffee').Vault
 
 module.exports = (robot, scripts) ->
+  robot.vault =
+    forUser: (user) ->
+      new Vault(user)
+
   robot.loadFile(Path.resolve(__dirname, "src", "scripts"), "http.coffee")
   robot.loadFile(Path.resolve(__dirname, "src", "scripts"), "token.coffee")
   robot.loadFile(Path.resolve(__dirname, "src", "scripts"), "deploy.coffee")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   ],
   "dependencies": {
     "coffeelint": "^1.14.2",
+    "fernet": "0.3.0",
     "hubot": ">=2.7.2 <=2.13.2",
-    "hubot-vault": "0.0.1",
     "inflection": "1.3.6",
     "ip-address": "5.0.2",
     "octonode": "0.7.4",

--- a/src/hubot/vault.coffee
+++ b/src/hubot/vault.coffee
@@ -1,0 +1,34 @@
+fernet = require 'fernet'
+
+class Vault
+  constructor: (@user) ->
+    @user?.vault or= {}
+    @vault = @user.vault
+
+  set: (key, value) ->
+    token = new fernet.Token(secret: @currentSecret())
+    @vault[key] = token.encode(JSON.stringify(value))
+
+  get: (key) ->
+    return unless @vault[key]
+    for secret in @secrets()
+      token = new fernet.Token
+        secret: secret
+        token: @vault[key]
+        ttl: 0
+      try
+        value = JSON.parse(token.decode())
+        return value
+      catch error
+        continue
+
+  unset: (key) ->
+    delete @vault[key]
+
+  currentSecret: ->
+    @secrets()[0]
+
+  secrets: ->
+    (new fernet.Secret(secret) for secret in process.env.HUBOT_FERNET_SECRETS.split(","))
+
+exports.Vault = Vault

--- a/test/scripts/deployment_test.coffee
+++ b/test/scripts/deployment_test.coffee
@@ -16,7 +16,6 @@ describe "Deploying from chat", () ->
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 
     robot.adapter.on "connected", () ->
-      require("hubot-vault")(robot)
       require("../../index")(robot)
 
       userInfo =

--- a/test/scripts/latest_deploys_test.coffee
+++ b/test/scripts/latest_deploys_test.coffee
@@ -15,7 +15,6 @@ describe "Latest deployments", () ->
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 
     robot.adapter.on "connected", () ->
-      require("hubot-vault")(robot)
       require("../../index")(robot)
 
       userInfo =

--- a/test/scripts/tokens_test.coffee
+++ b/test/scripts/tokens_test.coffee
@@ -15,7 +15,6 @@ describe "Setting tokens and such", () ->
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 
     robot.adapter.on "connected", () ->
-      require("hubot-vault")(robot)
       require("../../index")(robot)
 
       userInfo =


### PR DESCRIPTION
The `robot.forUser` method is confusing and not clearly scoped to the scripts it requires. The `hubot-vault` package also has a `store` attribute that seems unnecessary. This removes reliance on `hubot-vault` and should fix up #86.