### PR TITLE
Fixup errors where fernet secrets are absent in the ENV

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ In order to create deployments on GitHub you need to configure a few things. Fal
 |-------------------------|-------------------------------------------------|
 | HUBOT_GITHUB_API        | A String of the full URL to the GitHub API. Default: "https://api.github.com" |
 | HUBOT_GITHUB_TOKEN      | A [personal oauth token][1] with repo_deployment scope. This is normally a bot account. |
-| HUBOT_FERNET_SECRETS    | The key used for encrypting your tokens in the hubot's brain. |
+| HUBOT_DEPLOY_FERNET_SECRETS    | The key used for encrypting your tokens in the hubot's brain. A comma delimited set of different key tokens. To create one run `dd if=/dev/urandom bs=32 count=1 2>/dev/null | openssl base64` on a UNIX system.  |
 | HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS | If set to true a `github_deployment` event emit emitted instead of posting directly to the GitHub API. This allows for customization, check out the examples. |
 | HUBOT_DEPLOY_DEFAULT_ENVIRONMENT | Allow for specifying which environment should be the default when it is omitted from the deployment request in chat. |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/hubot/vault.coffee
+++ b/src/hubot/vault.coffee
@@ -4,6 +4,7 @@ class Vault
   constructor: (@user) ->
     @user?.vault or= {}
     @vault = @user.vault
+    @secrets = @getSecrets()
 
   set: (key, value) ->
     token = new fernet.Token(secret: @currentSecret())
@@ -11,7 +12,7 @@ class Vault
 
   get: (key) ->
     return undefined unless @vault[key]
-    for secret in @secrets()
+    for secret in @secrets
       token = new fernet.Token
         secret: secret
         token: @vault[key]
@@ -26,9 +27,12 @@ class Vault
     delete @vault[key]
 
   currentSecret: ->
-    @secrets()[0]
+    @secrets[0]
 
-  secrets: ->
-    (new fernet.Secret(secret) for secret in process.env.HUBOT_FERNET_SECRETS.split(","))
+  getSecrets: ->
+    unless process.env.HUBOT_DEPLOY_FERNET_SECRETS?
+      throw new Error("Please set a HUBOT_DEPLOY_FERNET_SECRETS string in the environment")
+    fernetSecrets = process.env.HUBOT_DEPLOY_FERNET_SECRETS.split(",")
+    (new fernet.Secret(secret) for secret in fernetSecrets)
 
 exports.Vault = Vault

--- a/test/scripts/deployment_test.coffee
+++ b/test/scripts/deployment_test.coffee
@@ -11,7 +11,7 @@ describe "Deploying from chat", () ->
 
   beforeEach (done) ->
     VCR.playback()
-    process.env.HUBOT_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
+    process.env.HUBOT_DEPLOY_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
     process.env.HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS = true
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 

--- a/test/scripts/latest_deploys_test.coffee
+++ b/test/scripts/latest_deploys_test.coffee
@@ -11,7 +11,7 @@ describe "Latest deployments", () ->
 
   beforeEach (done) ->
     VCR.playback()
-    process.env.HUBOT_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
+    process.env.HUBOT_DEPLOY_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 
     robot.adapter.on "connected", () ->

--- a/test/scripts/tokens_test.coffee
+++ b/test/scripts/tokens_test.coffee
@@ -11,7 +11,7 @@ describe "Setting tokens and such", () ->
 
   beforeEach (done) ->
     VCR.playback()
-    process.env.HUBOT_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
+    process.env.HUBOT_DEPLOY_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 
     robot.adapter.on "connected", () ->


### PR DESCRIPTION
If you don't have the correct environmental variables you get a code error instead of a meaningful one.

```
Hubot> [Wed Dec 30 2015 14:26:15 GMT-0800 (PST)] ERROR TypeError: Cannot read property 'split' of undefined
  at Vault.secrets (/Users/atmos/p/zf-hubot/node_modules/hubot-deploy/src/hubot/vault.coffee:32:6)
```