### PR TITLE
Add a deployment handler to verify incoming payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/github/webhooks/deployment.coffee
+++ b/src/github/webhooks/deployment.coffee
@@ -7,6 +7,7 @@ class Deployment
     @number      = deployment.id
     @sha         = deployment.sha.substring(0,7)
     @ref         = deployment.ref
+    @task        = deployment.task
     @environment = deployment.environment
     @notify      = deployment.payload.notify
 

--- a/src/models/handler.coffee
+++ b/src/models/handler.coffee
@@ -6,12 +6,14 @@ GitHubDeploymentStatus = require("../github/api").GitHubDeploymentStatus
 class Handler
   constructor: (@robot, @deployment) ->
     @ref              = @deployment.ref
+    @sha              = @deployment.sha
     @repoName         = @deployment.repoName
     @environment      = @deployment.environment
     @notify           = @deployment.notify
     @actualDeployment = @deployment.payload.deployment
     @provider         = @actualDeployment.payload?.config?.provider
     @number           = @actualDeployment.id
+    @task             = @actualDeployment.task
 
   run: (callback) ->
     try

--- a/src/models/handler.coffee
+++ b/src/models/handler.coffee
@@ -1,0 +1,26 @@
+Crypto       = require "crypto"
+Fernet       = require "fernet"
+
+GitHubDeploymentStatus = require("../github/api").GitHubDeploymentStatus
+
+class Handler
+  constructor: (@robot, @deployment) ->
+    @ref              = @deployment.ref
+    @repoName         = @deployment.repoName
+    @environment      = @deployment.environment
+    @notify           = @deployment.notify
+    @actualDeployment = @deployment.payload.deployment
+    @provider         = @actualDeployment.payload?.config?.provider
+    @number           = @actualDeployment.id
+
+  run: (callback) ->
+    try
+      unless @robot.name is @actualDeployment.payload.robotName
+        throw new Error "Received request for unintended robot #{@actualDeployment.payload.robotName}."
+      unless @notify?
+        throw new Error("Not deploying #{@repoName}/#{@ref} to #{@environment}. Not chat initiated.")
+      callback undefined, @
+    catch err
+      callback err, @
+
+exports.Handler = Handler

--- a/test/fixtures/deployments/production.json
+++ b/test/fixtures/deployments/production.json
@@ -7,6 +7,7 @@
     "task": "deploy",
     "payload": {
       "name": "my-robot",
+      "robotName": "hubot",
       "hosts": "",
       "notify": {
         "room": "ops",
@@ -27,7 +28,7 @@
       }
     },
     "environment": "production",
-    "description": "Deploying from hubot-deploy-v0.6.53",
+    "description": "Deploying from hubot-deploy-v0.12.5",
     "creator": {
       "login": "atmos",
       "id": 6626297,

--- a/test/fixtures/deployments/staging.json
+++ b/test/fixtures/deployments/staging.json
@@ -7,6 +7,7 @@
     "task": "deploy",
     "payload": {
       "name": "heaven",
+      "robotName": "hubot",
       "hosts": "",
       "notify": {
         "room": "ops",
@@ -27,7 +28,7 @@
       }
     },
     "environment": "staging",
-    "description": "Deploying from hubot-deploy-v0.6.53",
+    "description": "Deploying from hubot-deploy-v0.12.5",
     "creator": {
       "login": "atmos",
       "id": 6626297,

--- a/test/models/handler_test.coffee
+++ b/test/models/handler_test.coffee
@@ -64,12 +64,17 @@ describe "Deployment Handlers", () ->
       assert.equal err.message, "Not deploying atmos/my-robot/heroku to production. Not chat initiated."
       done()
 
-  it "dispatches to heroku", (done) ->
+  it "dispatches to specific providers", (done) ->
     fixturePayload = deploymentFixtureFor "production"
     deployment = new Deployment "uuid", fixturePayload
 
     handler = new Handler.Handler robot, deployment
     handler.run (err, handler) ->
       throw err if err
-      assert.equal "heroku", handler.provider
+      assert.equal "heroku",  handler.provider
+      assert.equal "heroku",  handler.ref
+      assert.equal "3c9f42c", handler.sha
+      assert.equal "1875476", handler.number
+      assert.equal "production", handler.environment
+      assert.equal "atmos/my-robot", handler.repoName
       done()

--- a/test/models/handler_test.coffee
+++ b/test/models/handler_test.coffee
@@ -50,7 +50,7 @@ describe "Deployment Handlers", () ->
     deployment = new Deployment "uuid", fixturePayload
 
     handler = new Handler.Handler robot, deployment
-    handler.run (err, provider) ->
+    handler.run (err, handler) ->
       assert.equal err.message, "Received request for unintended robot evilbot."
       done()
 
@@ -60,20 +60,16 @@ describe "Deployment Handlers", () ->
     deployment = new Deployment "uuid", fixturePayload
 
     handler = new Handler.Handler robot, deployment
-    handler.run (err, provider) ->
+    handler.run (err, handler) ->
       assert.equal err.message, "Not deploying atmos/my-robot/heroku to production. Not chat initiated."
       done()
-#
-#  it "blows up", (done) ->
-#    fixturePayload = deploymentFixtureFor "production"
-#    deployment = new Deployment "uuid", fixturePayload
-#
-#    handler = new Handler.Handler robot, deployment
-#    handler.run (err, provider) ->
-#      throw err if err
-#      console.log err
-#      switch provider
-#        when "heroku" then @heroku()
-#        else
-#          throw new Error "Unknown provider: #{provider}"
-#      done()
+
+  it "dispatches to heroku", (done) ->
+    fixturePayload = deploymentFixtureFor "production"
+    deployment = new Deployment "uuid", fixturePayload
+
+    handler = new Handler.Handler robot, deployment
+    handler.run (err, handler) ->
+      throw err if err
+      assert.equal "heroku", handler.provider
+      done()

--- a/test/models/handler_test.coffee
+++ b/test/models/handler_test.coffee
@@ -1,0 +1,79 @@
+Fs            = require "fs"
+VCR           = require "ys-vcr"
+Path          = require('path')
+Robot         = require "hubot/src/robot"
+TextMessage   = require("hubot/src/message").TextMessage
+GitHubEvents  = require(Path.join(__dirname, "..", "..", "src", "github", "webhooks"))
+Deployment    = GitHubEvents.Deployment
+
+Handler = require(Path.join(__dirname, "..", "..", "src", "models", "handler"))
+
+describe "Deployment Handlers", () ->
+  user = null
+  robot = null
+  adapter = null
+  deployment = null
+
+  beforeEach (done) ->
+    VCR.playback()
+    process.env.HUBOT_DEPLOY_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
+    process.env.HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS = true
+    robot = new Robot(null, "mock-adapter", true, "hubot")
+
+    robot.adapter.on "connected", () ->
+      require("../../index")(robot)
+
+      userInfo =
+        name: "atmos",
+        room: "#my-room"
+
+      user    = robot.brain.userForId "1", userInfo
+      adapter = robot.adapter
+
+      done()
+
+    robot.run()
+
+  afterEach () ->
+    delete(process.env.HUBOT_DEPLOY_DEFAULT_ENVIRONMENT)
+    VCR.stop()
+    robot.server.close()
+    robot.shutdown()
+
+  deploymentFixtureFor = (fixtureName) ->
+    fixtureData = Path.join __dirname, "..", "..", "test", "fixtures", "deployments", "#{fixtureName}.json"
+    JSON.parse(Fs.readFileSync(fixtureData))
+
+  it "only responds to the currently running bot name", (done) ->
+    fixturePayload = deploymentFixtureFor "production"
+    fixturePayload.deployment.payload.robotName = "evilbot"
+    deployment = new Deployment "uuid", fixturePayload
+
+    handler = new Handler.Handler robot, deployment
+    handler.run (err, provider) ->
+      assert.equal err.message, "Received request for unintended robot evilbot."
+      done()
+
+  it "ignores deployments that have no notify attrs in their payload", (done) ->
+    fixturePayload = deploymentFixtureFor "production"
+    delete fixturePayload.deployment.payload.notify
+    deployment = new Deployment "uuid", fixturePayload
+
+    handler = new Handler.Handler robot, deployment
+    handler.run (err, provider) ->
+      assert.equal err.message, "Not deploying atmos/my-robot/heroku to production. Not chat initiated."
+      done()
+#
+#  it "blows up", (done) ->
+#    fixturePayload = deploymentFixtureFor "production"
+#    deployment = new Deployment "uuid", fixturePayload
+#
+#    handler = new Handler.Handler robot, deployment
+#    handler.run (err, provider) ->
+#      throw err if err
+#      console.log err
+#      switch provider
+#        when "heroku" then @heroku()
+#        else
+#          throw new Error "Unknown provider: #{provider}"
+#      done()


### PR DESCRIPTION
Adds a callback handler to help scrub incoming deployments and only dispatch chat initiated ones that have providers set.

```coffeescript
module.exports = (robot) ->
  #########################################################################
  robot.on "github_deployment_event", (deployment) ->
    handler = new Handler robot, deployment
    handler.run (err, deployment) ->
      return robot.logger.info err if err
      robot.logger.info "Deploying #{deployment.repoName}@#{deployment.ref} to #{deployment.environment} on #{deployment.provider}"
      
```