### PR TITLE
Allow customization of GitHub subnets for IP verification

### DIFF
--- a/src/models/verifiers.coffee
+++ b/src/models/verifiers.coffee
@@ -23,7 +23,7 @@ class ApiTokenVerifier
 
 class GitHubWebHookIpVerifier
   constructor: () ->
-    gitHubSubnets = process.env.GITHUB_VERIFICATION_SUBNETS || "192.30.252.0/22"
+    gitHubSubnets = process.env.HUBOT_GITHUB_VERIFICATION_SUBNETS || "192.30.252.0/22"
     @subnets = gitHubSubnets.split(',').map (subnet) ->
       return subnet && new Address4(subnet.trim())
     .filter Boolean

--- a/src/models/verifiers.coffee
+++ b/src/models/verifiers.coffee
@@ -23,7 +23,10 @@ class ApiTokenVerifier
 
 class GitHubWebHookIpVerifier
   constructor: () ->
-    @subnets = [ new Address4("192.30.252.0/22") ]
+    gitHubSubnets = process.env.GITHUB_VERIFICATION_SUBNETS || "192.30.252.0/22"
+    @subnets = gitHubSubnets.split(',').map (subnet) ->
+      return subnet && new Address4(subnet.trim())
+    .filter Boolean
 
   ipIsValid: (ipAddress) ->
     address = new Address4("#{ipAddress}/24")

--- a/test/models/verifiers_test.coffee
+++ b/test/models/verifiers_test.coffee
@@ -5,7 +5,7 @@ Verifiers = require(Path.join(__dirname, "..", "..", "src", "models", "verifiers
 
 describe "GitHubWebHookIpVerifier", () ->
   afterEach () ->
-    delete process.env.GITHUB_VERIFICATION_SUBNETS
+    delete process.env.HUBOT_GITHUB_VERIFICATION_SUBNETS
 
   it "verifies correct ip addresses", () ->
     verifier = new Verifiers.GitHubWebHookIpVerifier
@@ -24,7 +24,7 @@ describe "GitHubWebHookIpVerifier", () ->
     assert.isFalse verifier.ipIsValid("127.0.0.1")
 
   it "verifies correct ip addresses with custom subnets", () ->
-    process.env.GITHUB_VERIFICATION_SUBNETS = '207.97.227.0/22,,   198.41.190.0/22'
+    process.env.HUBOT_GITHUB_VERIFICATION_SUBNETS = '207.97.227.0/22,,   198.41.190.0/22'
     verifier = new Verifiers.GitHubWebHookIpVerifier
 
     assert.isTrue verifier.ipIsValid("207.97.224.1")

--- a/test/models/verifiers_test.coffee
+++ b/test/models/verifiers_test.coffee
@@ -4,6 +4,9 @@ Path = require('path')
 Verifiers = require(Path.join(__dirname, "..", "..", "src", "models", "verifiers"))
 
 describe "GitHubWebHookIpVerifier", () ->
+  afterEach () ->
+    delete process.env.GITHUB_VERIFICATION_SUBNETS
+
   it "verifies correct ip addresses", () ->
     verifier = new Verifiers.GitHubWebHookIpVerifier
 
@@ -17,6 +20,19 @@ describe "GitHubWebHookIpVerifier", () ->
 
     assert.isFalse verifier.ipIsValid("192.30.250.1")
     assert.isFalse verifier.ipIsValid("192.30.251.1")
+    assert.isFalse verifier.ipIsValid("192.168.1.1")
+    assert.isFalse verifier.ipIsValid("127.0.0.1")
+
+  it "verifies correct ip addresses with custom subnets", () ->
+    process.env.GITHUB_VERIFICATION_SUBNETS = '207.97.227.0/22,,   198.41.190.0/22'
+    verifier = new Verifiers.GitHubWebHookIpVerifier
+
+    assert.isTrue verifier.ipIsValid("207.97.224.1")
+    assert.isTrue verifier.ipIsValid("198.41.188.1")
+
+    assert.isFalse verifier.ipIsValid("192.30.252.1")
+    assert.isFalse verifier.ipIsValid("207.97.228.1")
+    assert.isFalse verifier.ipIsValid("198.41.194.1")
     assert.isFalse verifier.ipIsValid("192.168.1.1")
     assert.isFalse verifier.ipIsValid("127.0.0.1")
 


### PR DESCRIPTION
Fixes [https://github.com/atmos/hubot-deploy/issues/91].

As suggested by @atmos, I've added `HUBOT_GITHUB_VERIFICATION_SUBNETS` as a new environment variable.  This is a comma delimited string of GitHub IP subnets.  Useful for teams that have deployed GitHub enterprise solutions and want to use `hubot-deploy`
