### PR TITLE
Set a ref attribute to the default branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/github/webhooks/commit_status.coffee
+++ b/src/github/webhooks/commit_status.coffee
@@ -4,12 +4,13 @@ class CommitStatus
     @targetUrl   = @payload.target_url
     @description = @payload.description
     @context     = @payload.context
+    @ref         = @payload.branches[0].name
     @sha         = @payload.sha.substring(0,7)
     @name        = @payload.repository.name
     @repoName    = @payload.repository.full_name
 
   toSimpleString: ->
-    msg = "hubot-deploy: commit status for #{@name}/#{@sha} (#{@context}) "
+    msg = "hubot-deploy: Build for #{@name}/#{@ref} (#{@context}) "
     switch @state
       when "success"
         msg += "was successful."

--- a/test/github/webhooks/commit_status_test.coffee
+++ b/test/github/webhooks/commit_status_test.coffee
@@ -17,18 +17,18 @@ describe "GitHubEvents.CommitStatus fixtures", () ->
       status = deploymentStatusFor "pending"
       assert.equal status.state, "pending"
       assert.equal status.repoName, "atmos/my-robot"
-      assert.equal status.toSimpleString(), "hubot-deploy: commit status for atmos/1333c01 (Janky (github)) is running. https://ci.atmos.org/1123112/output"
+      assert.equal status.toSimpleString(), "hubot-deploy: Build for atmos/master (Janky (github)) is running. https://ci.atmos.org/1123112/output"
 
   describe "failure", () ->
     it "knows the status and repo", () ->
       status = deploymentStatusFor "failure"
       assert.equal status.state, "failure"
       assert.equal status.repoName, "atmos/my-robot"
-      assert.equal status.toSimpleString(), "hubot-deploy: commit status for my-robot/f911111 (Janky (github)) failed. https://baller.com/target_stuff"
+      assert.equal status.toSimpleString(), "hubot-deploy: Build for my-robot/jroes-patch-4 (Janky (github)) failed. https://baller.com/target_stuff"
 
   describe "success", () ->
     it "knows the status and repo", () ->
       status = deploymentStatusFor "success"
       assert.equal status.state, "success"
       assert.equal status.repoName, "atmos/my-robot"
-      assert.equal status.toSimpleString(), "hubot-deploy: commit status for github/1333c01 (Janky (github)) was successful. https://ci.atmos.org/1123112/output"
+      assert.equal status.toSimpleString(), "hubot-deploy: Build for github/master (Janky (github)) was successful. https://ci.atmos.org/1123112/output"


### PR DESCRIPTION
Use the array of branches in commit status payloads to do a best guess at the branch the build was for.


/cc @jroes