### PR TITLE
Fix slack user name

### DIFF
--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -107,6 +107,9 @@ module.exports = (robot) ->
       if msg.envelope.user.reply_to?
         deployment.room = msg.envelope.user.reply_to
 
+    if robot.adapterName is "slack"
+      deployment.user = user.name
+
     deployment.yubikey   = yubikey
     deployment.adapter   = robot.adapterName
     deployment.robotName = robot.name


### PR DESCRIPTION
This should fix second issue of #59.

The following is the response of `hubot who am i` using Slack:

```
id: U024ZEPMY
name: dlackty
real_name: Richard Lee
email_address: REDACTED
slack: [object Object]
reply_to: C024ZUJH7
room: web
githubLogin: dlackty
vault: [object Object]
@dlackty: You are known as dlackty on GitHub
```