### PR TITLE
Try releasing a new version to start injecting middleware

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,10 +6,13 @@ In order to create deployments on GitHub you need to configure a few things. Fal
 |-------------------------|-------------------------------------------------|
 | HUBOT_GITHUB_API        | A String of the full URL to the GitHub API. Default: "https://api.github.com" |
 | HUBOT_GITHUB_TOKEN      | A [personal oauth token][1] with repo_deployment scope. This is normally a bot account. |
+| HUBOT_DEPLOY_PREFIX     | The thing to prefix your deployment commands with. Defaults to 'deploy' |
 | HUBOT_DEPLOY_FERNET_SECRETS    | The key used for encrypting your tokens in the hubot's brain. A comma delimited set of different key tokens. To create one run `dd if=/dev/urandom bs=32 count=1 2>/dev/null | openssl base64` on a UNIX system.  |
 | HUBOT_DEPLOY_EMIT_GITHUB_DEPLOYMENTS | If set to true a `github_deployment` event emit emitted instead of posting directly to the GitHub API. This allows for customization, check out the examples. |
 | HUBOT_DEPLOY_DEFAULT_ENVIRONMENT | Allow for specifying which environment should be the default when it is omitted from the deployment request in chat. |
 | HUBOT_DEPLOY_GITHUB_SUBNETS | Allow for specifying the subnets for your GitHub install, useful for GitHub Enterprise. Defaults to github.com's IP range. |
+| HUBOT_DEPLOY_PRIVATE_MESSAGE_TOKEN_MANAGEMENT | Allow for messaging tokens to hubot in chat. This is going away. |
+| HUBOT_DEPLOY_WEBHOOK_SECRET | The shared webhook secret to check payload signatures from GitHub. |
 
 ### Robot Users
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.12.12",
+  "version": "0.13.0",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -31,7 +31,7 @@ module.exports = (robot) ->
   # where can i deploy <app>
   #
   # Displays the available environments for an application
-  robot.respond ///where\s+can\s+i\s+#{DeployPrefix}\s+([-_\.0-9a-z]+)///i, (msg) ->
+  robot.respond ///where\s+can\s+i\s+#{DeployPrefix}\s+([-_\.0-9a-z]+)///i, id: "hubot-deploy.wcid", (msg) ->
     name = msg.match[1]
 
     try
@@ -46,8 +46,8 @@ module.exports = (robot) ->
   ###########################################################################
   # deploys <app> in <env>
   #
-  # Displays the available environments for an application
-  robot.respond DeploysPattern, (msg) ->
+  # Displays the recent deployments for an application in an environment
+  robot.respond DeploysPattern, id: "hubot-deploy.recent", hubotDeployAuthenticate: true, (msg) ->
     name        = msg.match[2]
     environment = msg.match[4] || defaultDeploymentEnvironment()
 
@@ -70,7 +70,7 @@ module.exports = (robot) ->
   # deploy hubot/topic-branch to staging
   #
   # Actually dispatch deployment requests to GitHub
-  robot.respond DeployPattern, (msg) ->
+  robot.respond DeployPattern, id: "hubot-deploy.create", hubotDeployAuthenticate: true, (msg) ->
     task  = msg.match[1].replace(DeployPrefix, "deploy")
     force = msg.match[2] == '!'
     name  = msg.match[3]
@@ -121,5 +121,5 @@ module.exports = (robot) ->
   # deploy:version
   #
   # Useful for debugging
-  robot.respond ///#{DeployPrefix}\:version$///i, (msg) ->
+  robot.respond ///#{DeployPrefix}\:version$///i, id: "hubot-deploy.version", (msg) ->
     msg.send "hubot-deploy v#{Version}/hubot v#{robot.version}/node #{process.version}"

--- a/test/scripts/tokens_test.coffee
+++ b/test/scripts/tokens_test.coffee
@@ -11,6 +11,7 @@ describe "Setting tokens and such", () ->
 
   beforeEach (done) ->
     VCR.playback()
+    process.env.HUBOT_DEPLOY_PRIVATE_MESSAGE_TOKEN_MANAGEMENT = "true"
     process.env.HUBOT_DEPLOY_FERNET_SECRETS or= "HSfTG4uWzw9whtlLEmNAzscHh96eHUFt3McvoWBXmHk="
     robot = new Robot(null, "mock-adapter", true, "Hubot")
 


### PR DESCRIPTION
We started using [Listener Middlware](https://github.com/github/hubot/blob/master/docs/scripting.md#listener-middleware) at heroku to allow us to attach user credentials from something other than hubot's brain. This allows us to do away with the hubot-deploy 'vault' concept and let people defer to something that is better than private messaging the bot their tokens.

If you're still using the `deploy-token:set` syntax you need to enable the `HUBOT_DEPLOY_PRIVATE_MESSAGE_TOKEN_MANAGEMENT` var.

