### PR TITLE
expose merged attribute

### DIFF
--- a/src/github/webhooks/pull_request.coffee
+++ b/src/github/webhooks/pull_request.coffee
@@ -5,6 +5,7 @@ class PullRequest
     @title       = @payload.pull_request.title
     @branch      = @payload.pull_request.head.ref
     @state       = @payload.pull_request.state
+    @merged      = @payload.pull_request.merged
     @action      = @payload.action
     @number      = @payload.number
     @repoName    = @payload.repository.full_name


### PR DESCRIPTION
Allow downstream event consumers to know about the merged PR event attribute.