### PR TITLE
Fix issue #105 - support github enterprise for token verifier

### DIFF
--- a/src/models/verifiers.coffee
+++ b/src/models/verifiers.coffee
@@ -12,7 +12,14 @@ class ApiTokenVerifier
     @token = token?.trim()
 
     @config = new GitHubApi(@token, null)
-    @api   = Octonode.client(@config.token, {hostname: @config.hostname})
+
+    hostname = @config.hostname
+    path = @config.path()
+
+    if path isnt "/"
+      hostname += path
+
+    @api   = Octonode.client(@config.token, {hostname: hostname})
 
   valid: (cb) ->
     @api.get "/user", (err, status, data, headers) ->


### PR DESCRIPTION
This is a patch to fix https://github.com/atmos/hubot-deploy/issues/105 to support `deploy-token:set:github` on GitHub Enterprise