### PR TITLE
Make the verifiers return falls on an empty token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-deploy",
-  "version": "0.13.24",
+  "version": "0.13.25",
   "author": "Corey Donohoe <atmos@atmos.org>",
   "description": "hubot script for GitHub Flow",
   "main": "index.coffee",

--- a/src/models/verifiers.coffee
+++ b/src/models/verifiers.coffee
@@ -45,6 +45,7 @@ class GitHubTokenVerifier
     @token = token?.trim()
 
   valid: (cb) ->
+    cb(false) unless token?
     ScopedClient.create("https://api.github.com").
       header("User-Agent", "hubot-deploy/0.13.1").
       header("Authorization", "token #{@token}").
@@ -66,6 +67,7 @@ class HerokuTokenVerifier
     @token = token?.trim()
 
   valid: (cb) ->
+    cb(false) unless token?
     ScopedClient.create("https://api.heroku.com").
       header("Accept", "application/vnd.heroku+json; version=3").
       header("Authorization", "Bearer #{@token}").


### PR DESCRIPTION
During the GitHub outage last night our service that constantly refreshes our GitHub oauth tokens null'd out everyone's tokens. The API treats an empty token as an anonymous request and you get a crazy but unhelpful response from the API.

`API rate limit exceeded for w.x.y.z. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation...`