### PR TITLE
Updated Slack name and room determination logic

### DIFF
--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -76,6 +76,10 @@ module.exports = (robot) ->
       if robot.adapterName is "hipchat"
         if msg.envelope.user.reply_to?
           deployment.room = msg.envelope.user.reply_to
+          
+      if robot.adapterName is "slack"
+        deployment.user = user.name
+        deployment.room = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById(msg.message.user.room).name
 
       deployment.adapter   = robot.adapterName
       deployment.robotName = robot.name
@@ -127,6 +131,10 @@ module.exports = (robot) ->
     if robot.adapterName is "hipchat"
       if msg.envelope.user.reply_to?
         deployment.room = msg.envelope.user.reply_to
+
+    if robot.adapterName is "slack"
+      deployment.user = user.name
+      deployment.room = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById(msg.message.user.room).name
 
     deployment.yubikey   = yubikey
     deployment.adapter   = robot.adapterName


### PR DESCRIPTION
Since Hubot-Slack 4.0.0 Slack returns the user ID and room ID rather than their names.

This commit:

1. Checks if the adapter is Slack and, if so, sets `user.name`.

2. Uses the channel ID to pull the channel name from the Slack client cache.

c.f. https://slackapi.github.io/hubot-slack/upgrading#upgrading-from-version-3-or-earlier