### PR TITLE
Added aws instance type to parser, with tests

### DIFF
--- a/src/github/api/deployment.coffee
+++ b/src/github/api/deployment.coffee
@@ -10,7 +10,7 @@ GitHubApi = require(Path.join(__dirname, "..", "api")).Api
 class Deployment
   @APPS_FILE = process.env['HUBOT_DEPLOY_APPS_JSON'] or "apps.json"
 
-  constructor: (@name, @ref, @task, @env, @force, @hosts) ->
+  constructor: (@name, @ref, @task, @env, @force, @hosts, @aws_instance_type) ->
     @room             = 'unknown'
     @user             = 'unknown'
     @adapter          = 'unknown'
@@ -86,6 +86,8 @@ class Deployment
         message_id: @messageId
         thread_id: @threadId
       config: @application
+      aws_deploy_config:
+        aws_instance_type: @aws_instance_type
 
   setUserToken: (token) ->
     @userToken = token.trim()

--- a/src/models/patterns.coffee
+++ b/src/models/patterns.coffee
@@ -4,6 +4,8 @@ validSlug = "([-_\.0-9a-z]+)"
 
 scriptPrefix = process.env['HUBOT_DEPLOY_PREFIX'] || "deploy"
 
+validInstanceType = "t2.small|m3.large"
+
 # The :hammer: regex that handles all /deploy requests
 DEPLOY_SYNTAX = ///
   (#{scriptPrefix}(?:\:[^\s]+)?)        # / prefix
@@ -13,7 +15,9 @@ DEPLOY_SYNTAX = ///
   (?:\s+(?:to|in|on)\s+                 # http://i.imgur.com/3KqMoRi.gif
   #{validSlug}                          # Environment to release to
   (?:\/([^\s]+))?)?\s*                  # Host filter to try
-  (?:([cbdefghijklnrtuv]{32,64}|\d{6})?\s*)?$ # Optional Yubikey
+  (?:([cbdefghijklnrtuv]{32,64}|\d{6})?\s*)? # Optional Yubikey
+  (?:\s*(?:to|in|on)\s+
+  (#{validInstanceType}))?\s*$          # AWS Instance Type
 ///i
 
 

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -103,8 +103,9 @@ module.exports = (robot) ->
     env   = (msg.match[5]||defaultDeploymentEnvironment())
     hosts = (msg.match[6]||'')
     yubikey = msg.match[7]
+    aws_instance_type = (msg.match[8]||'')
 
-    deployment = new Deployment(name, ref, task, env, force, hosts)
+    deployment = new Deployment(name, ref, task, env, force, hosts, aws_instance_type)
 
     unless deployment.isValidApp()
       msg.reply "#{name}? Never heard of it."

--- a/test/models/pattern_test.coffee
+++ b/test/models/pattern_test.coffee
@@ -52,6 +52,26 @@ describe "Patterns", () ->
       assert.equal "production",  matches[5], "incorrect environment name"
       assert.equal undefined,     matches[6], "incorrect branch name"
 
+    it "handles deploying to environments with aws config", () ->
+      matches = "deploy hubot to production on t2.small".match(DeployPattern)
+      assert.equal "deploy",      matches[1], "incorrect task"
+      assert.equal "hubot",       matches[3], "incorrect app name"
+      assert.equal undefined,     matches[4], "incorrect branch name"
+      assert.equal "production",  matches[5], "incorrect environment name"
+      assert.equal undefined,     matches[6], "incorrect branch name"
+      assert.equal undefined,     matches[7], "incorrect authenticator token"
+      assert.equal "t2.small",    matches[8], "incorrect aws config"
+
+    it "handles deploying to environments with aws config large", () ->
+      matches = "deploy hubot to production on m3.large".match(DeployPattern)
+      assert.equal "deploy",      matches[1], "incorrect task"
+      assert.equal "hubot",       matches[3], "incorrect app name"
+      assert.equal undefined,     matches[4], "incorrect branch name"
+      assert.equal "production",  matches[5], "incorrect environment name"
+      assert.equal undefined,     matches[6], "incorrect branch name"
+      assert.equal undefined,     matches[7], "incorrect authenticator token"
+      assert.equal "m3.large",    matches[8], "incorrect aws config"
+
     it "handles environments with hosts", () ->
       matches = "deploy hubot to production/fe".match(DeployPattern)
       assert.equal "deploy",      matches[1], "incorrect task"


### PR DESCRIPTION
This adds the ability to parse out the instance type from the deploy message.

I've currently only added two types of instances (t2.small and m3.large), but we can add more/generalize that code to allow for any instance if we want to later. For now, we should only need these two.

